### PR TITLE
Refactor HttpRequest to use Uri for API endpoint

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <Process.hpp>
 #include <ProcessHandle.hpp>
 #include <string.hpp>
+#include <Uri.hpp>
 
 using namespace soup;
 
@@ -94,7 +95,7 @@ int main()
 	std::cout << authz << std::endl;
 	std::cout << "Downloading inventory... ";
 	// Note: Could also use api.warframe.com
-	HttpRequest hr("mobile.warframe.com", "/api/inventory.php" + authz);
+	HttpRequest hr(Uri("https://mobile.warframe.com/api/inventory.php" + authz));
 	auto res = hr.execute();
 	SOUP_IF_UNLIKELY (!res)
 	{


### PR DESCRIPTION
Was running into an error when running the tool.
```
Gruzzling... The crumbs have been gruzzled.
<redacted>
Downloading inventory... Request failed.
```
So I ran
`curl -v "http://mobile.warframe.com/api/inventory.php?accountId=<redacted>&nonce=<redacted>"`
```
* Host mobile.warframe.com:80 was resolved.
* IPv6: (none)
* IPv4: 23.11.2.75
*   Trying 23.11.2.75:80...
* Connected to mobile.warframe.com (23.11.2.75) port 80
* using HTTP/1.x
> GET /api/inventory.php?<redacted>
> Host: mobile.warframe.com
> User-Agent: curl/8.13.0
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Content-Length: 0
< Location: https://mobile.warframe.com/api/inventory.php?<redacted>
< Expires: Mon, 25 May 2026 08:23:55 GMT
< Cache-Control: max-age=0, no-cache, no-store
< Pragma: no-cache
< Date: Mon, 25 May 2026 08:23:55 GMT
< Connection: keep-alive
<
* Connection #0 to host mobile.warframe.com left intact
```
Same error with the api.warframe.com endpoint as well.

`curl -v "https://mobile.warframe.com/api/inventory.php?accountId=<redacted>&nonce=<redacted>"` produced the JSON as expected, as did https://api.warframe.com.

Nice and simple fix. Always a good time.

I compiled my patched version, and it ran just fine, at least on Windows.